### PR TITLE
fix(layout): vertically center identity content

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,15 +1,17 @@
 /* Importing Bootstrap SCSS file. */
-$backgroud-color: #303030;
+$background-color: #303030;
 $text-color: #fff;
 
-html,
-body,
-#app {
+html {
   height: 100%;
-  width: 100%;
+  background-color: $background-color;
 }
 
 body {
+  height: 100%;
   margin: 0;
-  background-color: $backgroud-color;
+}
+
+#app {
+  height: 100%;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,8 +2,14 @@
 $backgroud-color: #303030;
 $text-color: #fff;
 
-body {
-  height: 100vh;
+html,
+body,
+#app {
+  height: 100%;
   width: 100%;
+}
+
+body {
+  margin: 0;
   background-color: $backgroud-color;
 }


### PR DESCRIPTION
## Summary
- After the Vue migration, the heading, description and social-icon list rendered at the top of the page instead of being vertically centered.
- The Identity component already uses Bootstrap's `d-flex flex-column justify-content-center align-items-center h-100`, but `h-100` only works when every parent has an explicit height. The chain was broken at `<div id="app">` (Vue's mount node), which had no height set, so the inner `h-100` collapsed to its content height.
- Adds `height: 100%` to `html`, `body`, and `#app` in `src/styles.scss` (and zeroes the body margin) so the height cascade reaches Identity and `justify-content-center` actually fills the viewport.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Open the site in a browser and confirm the name, tagline, location and icon row sit centered both horizontally and vertically
- [ ] Resize the window to verify centering holds at multiple viewport heights

https://claude.ai/code/session_01A7JERg8NhYpWW14SQwGRz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7JERg8NhYpWW14SQwGRz7)_